### PR TITLE
Add admin navigation links for authenticated users

### DIFF
--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -12,8 +12,9 @@ import {
   ListItemButton,
   ListItemText,
 } from '@mui/material'
-import { Menu, X } from 'lucide-react'
+import { Menu, X, Settings } from 'lucide-react'
 import { useLenis } from '../hooks/useLenis'
+import { useAuth } from '../contexts/AuthContext'
 
 const Navigation = () => {
   const [mobileOpen, setMobileOpen] = useState(false)
@@ -23,6 +24,7 @@ const Navigation = () => {
   const location = useLocation()
   const navigate = useNavigate()
   const { lenis, scrollTo } = useLenis()
+  const { isAdmin } = useAuth()
 
   useEffect(() => {
     if (!lenis) return
@@ -154,6 +156,20 @@ const Navigation = () => {
                 {item.text}
               </Button>
             ))}
+            {isAdmin && (
+              <IconButton
+                onClick={() => navigate('/admin')}
+                sx={{
+                  color: '#ffffff',
+                  '&:hover': {
+                    backgroundColor: 'rgba(255, 255, 255, 0.1)',
+                  },
+                }}
+                aria-label="Admin panel"
+              >
+                <Settings size={20} />
+              </IconButton>
+            )}
           </Box>
 
           {/* Mobile Menu Button */}
@@ -212,6 +228,31 @@ const Navigation = () => {
                 </ListItemButton>
               </ListItem>
             ))}
+            {isAdmin && (
+              <ListItem disablePadding>
+                <ListItemButton
+                  onClick={() => {
+                    navigate('/admin')
+                    setMobileOpen(false)
+                  }}
+                  sx={{
+                    textAlign: 'center',
+                    color: '#ffffff',
+                    '&:hover': {
+                      backgroundColor: 'rgba(255, 255, 255, 0.1)',
+                    },
+                  }}
+                >
+                  <ListItemText
+                    primary="Admin"
+                    primaryTypographyProps={{
+                      fontSize: '1.2rem',
+                      fontWeight: 400,
+                    }}
+                  />
+                </ListItemButton>
+              </ListItem>
+            )}
           </List>
         </Box>
       </Drawer>

--- a/src/components/admin/AdminSidebar.tsx
+++ b/src/components/admin/AdminSidebar.tsx
@@ -1,4 +1,4 @@
-import { NavLink } from 'react-router-dom'
+import { NavLink, Link } from 'react-router-dom'
 import {
   Drawer,
   List,
@@ -10,7 +10,7 @@ import {
   Typography,
   Box,
 } from '@mui/material'
-import { LayoutDashboard, Clock, Images } from 'lucide-react'
+import { LayoutDashboard, Clock, Images, ExternalLink } from 'lucide-react'
 
 const DRAWER_WIDTH = 240
 
@@ -29,13 +29,30 @@ export default function AdminSidebar({ mobileOpen, onDrawerToggle }: AdminSideba
   const drawerContent = (
     <>
       <Toolbar>
-        <Box>
+        <Box sx={{ width: '100%' }}>
           <Typography variant="h6" fontWeight="bold">
             Admin
           </Typography>
-          <Typography variant="caption" color="text.secondary">
-            avec plaisir
-          </Typography>
+          <Link
+            to="/"
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: '4px',
+              textDecoration: 'none',
+            }}
+          >
+            <Typography
+              variant="caption"
+              sx={{
+                color: 'text.secondary',
+                '&:hover': { color: 'primary.main' },
+              }}
+            >
+              avec plaisir
+            </Typography>
+            <ExternalLink size={12} style={{ color: 'inherit' }} />
+          </Link>
         </Box>
       </Toolbar>
       <List>


### PR DESCRIPTION
Show admin panel link in main navigation (settings icon on desktop, "Admin" menu item on mobile) only when user is logged in as admin. Add link back to main site from admin sidebar.